### PR TITLE
Avoid reinstalling grunt and bower globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "preinstall": "npm install -g bower grunt-cli",
     "postinstall": "npm rebuild gulp-sass node-sass"
   }
 }


### PR DESCRIPTION
Better to ask the user to `npm install -g grunt bower` in the Docs, than try to install them without his concent
(specially cause it needs sudo sometimes, and if network fails, it can break the already installed grunt or bower)